### PR TITLE
Add arm32-only support

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,13 @@ meson setup --cross-file=aarch64-linux-android-ndk.txt build-aarch64-linux-andro
 meson compile -C build-aarch64-linux-android
 ```
 
+For `arm32`, use:
+
+```
+meson setup --cross-file=arm-linux-androideabi-ndk.txt build-arm-linux-androideabi
+meson compile -C build-arm-linux-androideabi
+```
+
 For `x86_64`, use:
 
 ```
@@ -56,6 +63,8 @@ adb root
 adb remount
 # for aarch64
 adb push build-aarch64-linux-android/vndk_meson /vendor/bin
+# for arm32
+adb push build-arm-linux-androideabi/vndk_meson /vendor/bin
 # for x86_64
 adb push build-x86_64-linux-android/vndk_meson /vendor/bin
 ```

--- a/arm-linux-androideabi-ndk.txt
+++ b/arm-linux-androideabi-ndk.txt
@@ -1,0 +1,31 @@
+# SPDX-License-Identifier: CC0-1.0
+
+[constants]
+# TODO: edit these paths for your own locations
+ndk = '/home/mkorpershoek/work/aosp/android-ndk-r26b/'
+
+# see: https://android.googlesource.com/platform/ndk/+/master/docs/BuildSystemMaintainers.md#target-selection
+triple = 'armv7a-linux-androideabi'
+android_api_level = '33'
+target = triple + android_api_level
+
+toolchain = ndk / 'toolchains/llvm/prebuilt/linux-x86_64/bin'
+
+[properties]
+cpp_stdlib = 'vndk'
+
+[built-in options]
+cpp_args = ['-target', target]
+
+[binaries]
+c = toolchain / target + '-clang'
+cpp = toolchain / target + '-clang++'
+ar = toolchain / 'llvm-ar'
+strip = toolchain / 'llvm-strip'
+config = toolchain / 'llvm-config'
+
+[host_machine]
+system = 'linux'
+cpu_family ='arm'
+cpu = 'cortex-a57.cortex-a53'
+endian = 'little'

--- a/subprojects/packagefiles/vndk/meson.build
+++ b/subprojects/packagefiles/vndk/meson.build
@@ -10,6 +10,9 @@ if cpu_family == 'x86_64'
 elif cpu_family == 'aarch64'
   cpu = 'arm64'
   prebuilt_path = cpu / 'arch-arm64-armv8-a/shared'
+elif cpu_family == 'arm'
+  cpu = 'arm'
+  prebuilt_path = cpu / 'arch-arm-armv7-a-neon/shared'
 else
     error('Architecture:  ' + cpu_family + ' not supported')
 endif


### PR DESCRIPTION
Low end Android devices can have 32 bit only userspace. Support that as well by adding a new cross file.